### PR TITLE
Make sure we define window.orientation getter at the right point in time

### DIFF
--- a/boar/plugins/window-orientation-usage.js
+++ b/boar/plugins/window-orientation-usage.js
@@ -17,16 +17,18 @@ WindowOrientationUsage.prototype.init = function (page) {
 WindowOrientationUsage.prototype.onInitialized = function () {
   var self = this;
   if (!self._started) {
-    self._page.evaluate(function(){
-      var messageString = arguments[0];
-      Object.defineProperty(window, 'orientation', { 
-        get: function () {
-          console.log(messageString);
-          return 1;
-        }
-      });
-    }, [messageString]);
-    self._started = true;
+    if (self._page.url) {
+      self._page.evaluate(function(){
+        var messageString = arguments[0];
+        Object.defineProperty(window, 'orientation', {
+          get: function () {
+            console.log(messageString);
+            return 1;
+          }
+        });
+      }, [messageString]);
+      self._started = true;
+    }
   }
 };
 


### PR DESCRIPTION
This should fix the window.orientation Gecko failure noted in https://github.com/Asynchq/boar/pull/40