### PR TITLE
Added redirects tracking

### DIFF
--- a/boar/tab.js
+++ b/boar/tab.js
@@ -17,6 +17,7 @@ var Tab = function (ip, port, hubPort) {
   this._busy = false;
   this._consoleLog = [];
   this._errorLog = [];
+  this._redirects = {};
   this.init(ip, port, hubPort);
 };
 
@@ -147,6 +148,11 @@ Tab.prototype._onResourceReceived = function (response) {
     default:
       break;
   }
+
+  if (response.redirectURL) {
+    self._redirects[response.url] = response.redirectURL;
+  }
+
   self._orphanResources.splice(self._orphanResources.indexOf(response.id), 1);
   self._resources[response.id].response = response;
   //console.log('Response (#' + response.id + ', stage "' + response.stage + '"): ' + JSON.stringify(self._resources[response.id]));
@@ -355,14 +361,14 @@ Tab.prototype._getConsoleLog = function (callback) {
 Tab.prototype._getErrorLog = function (callback) {
   var self = this;
   callback({
-    consoleLog: self._errorLog
+    errorLog: self._errorLog
   });
 };
 
 
 Tab.prototype._clearConsoleLog = function (callback) {
   this._consoleLog.length = 0;
-}
+};
 
 Tab.prototype._getCookies = function (callback) {
   callback({
@@ -387,6 +393,14 @@ Tab.prototype._getPluginResults = function (callback) {
   var self = this;
   callback({
     results: self._pluginManager.getResults()
+  });
+};
+
+
+Tab.prototype._getRedirects = function (callback) {
+  var self = this;
+  callback({
+    redirects: self._redirects
   });
 };
 
@@ -480,6 +494,10 @@ Tab.prototype._handleRequest = function (request, response) {
     case "/getPluginResults":
       self._resetAutoDestruct();
       self._getPluginResults(callback);
+      break;
+    case "/getRedirects":
+      self._resetAutoDestruct();
+      self._getRedirects(callback);
       break;
     default:
       console.log("WHAT DO YOU WANT?");

--- a/example.py
+++ b/example.py
@@ -41,7 +41,7 @@ data = {'script': 'var x = function(){ console.log("HELP"); }; x();'}
 response = do_command(url, "evaluateOnGecko", data)
 
 # Open URL
-data = {'url': 'http://www.holidaycheck.de', 'waitForResources': False}
+data = {'url': 'http://www.google.com', 'waitForResources': False}
 response = do_command(url, "open", data)
 
 data = {'timeout': 60000}
@@ -79,5 +79,6 @@ response = do_command(url, "getConsoleLog")
 response = do_command(url, "getPluginResults")
 
 response = do_command(url, "getErrorLog")
+response = do_command(url, "getRedirects")
 # Destroy Tab
 response = do_command(url, "destroy")

--- a/tests/integration/loggingTest.js
+++ b/tests/integration/loggingTest.js
@@ -27,7 +27,7 @@ describe(process.env.ENGINE + ' Logging', () => {
         return client.getErrorLog();
       })
       .then((data) => {
-        data.consoleLog.length.should.be.equal(0);
+        data.errorLog.length.should.be.equal(0);
         done();
       })
       .catch(done);
@@ -40,7 +40,7 @@ describe(process.env.ENGINE + ' Logging', () => {
         return client.getErrorLog();
       })
       .then((data) => {
-        data.consoleLog.length.should.be.equal(1);
+        data.errorLog.length.should.be.equal(1);
         done();
       })
       .catch(done);
@@ -53,7 +53,7 @@ describe(process.env.ENGINE + ' Logging', () => {
         return client.getErrorLog();
       })
       .then((data) => {
-        data.consoleLog.length.should.be.equal(1);
+        data.errorLog.length.should.be.equal(1);
         done();
       })
       .catch(done);
@@ -66,7 +66,7 @@ describe(process.env.ENGINE + ' Logging', () => {
         return client.getErrorLog();
       })
       .then((data) => {
-        data.consoleLog.length.should.be.equal(0);
+        data.errorLog.length.should.be.equal(0);
         done();
       })
       .catch(done);


### PR DESCRIPTION
Redirects now can be requested via getRedirects which will return a dict of src:target
```js
{
    "redirects": {
        "http://www.google.com/" : "http://www.google.de/?gfe_rd=cr&ei=tXaLVovoC6mI8QfixYXgDA",
        "http://www.google.de/?gfe_rd=cr&ei=tXaLVovoC6mI8QfixYXgDA" : "https://www.google.de/?gfe_rd=cr&ei=tXaLVovoC6mI8QfixYXgDA&gws_rd=ssl"
    }
}
```
